### PR TITLE
Update dependency of less-rails to newest release (3.0.0)

### DIFF
--- a/less-rails-semantic_ui.gemspec
+++ b/less-rails-semantic_ui.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency     'less-rails', '>= 2.6.0', '< 2.8.0'
+  spec.add_runtime_dependency     'less-rails', '>= 3.0.0', '< 3.1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
This will resolve messages like: 

> DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
> Please register a mime type using `register_mime_type` then
> use `register_compressor` or `register_transformer`.

Read more about issue here: https://github.com/metaskills/less-rails/issues/122

There are several threads about issues related to this, that this should resolve for.
